### PR TITLE
Update to Python 3 and fix latitude/longitude

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ sbucket.py 100
 $
 ```
 
-Without sbucket selection (world-wide 500 probes): 
+Without sbucket selection (world-wide 500 probes):
 ![alt text](https://github.com/cod3monk/RIPE-Atlas-sbucket/raw/master/without-sbucket.png "Map without sbucket.")
 
 The distribution is biased, because it prefers areas with a high density of probes. Here you can see the global distribution of probes by country code:
@@ -55,13 +55,13 @@ After application of the spacial bucket algorithm this distribution has a much l
 ![alt text](https://github.com/cod3monk/RIPE-Atlas-sbucket/raw/master/SB500-probes-per-country.png "Probe Numbers by Country (WW500).")
 
 ## Algorithm
-It tries to find a grid with roughly square cells where the number of cells by iterating over grid sizes. It stops after a grid was found which yields the number of probes (with a 5% error margin) OR a maximum number of iterations have been performed.
+It tries to find a grid with the right number of cells by iterating over grid sizes. It stops after a grid was found which yields the number of probes (with a 5% error margin) OR a maximum number of iterations have been performed.
 
 If the number of probes is bellow the targeted count, the cell number is increased (vertically and horizontally) by 50%, otherwise it is reduce by 10%.
 
-Within one cell a random probe is selected.
+Within one cell a random probe is selected.  Grid cells are roughly square.
 
 ## Known Problems
  * Selection might yield more or less probes then expected, no guarantees here, but it works well for larger numbers (>20).
- * The grid is set between 85 degrees north and east, this might be a problem with other projections than mercartor
+ * The grid is set between 85 degrees north and south, this might be a problem with other projections than Mercator.
  

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
     # installed, specify them here.  If using Python 2.6 or less, then these
     # have to be included in MANIFEST.in as well.
     package_data={
-        'pyproj': 'README.md',
+        'pyproj': ['README.md'],
     },
 
     # Although 'package_data' is the preferred approach, in some case you may


### PR DESCRIPTION
I tried to make this work with Python 3.8 or 3.10 since it hadn't been updated in a while.
I changed the order of longitude/latitude in the probe data according to the GeoJSON spec (RFC 7946).
I also cleaned it up a little and sped up coordinate transformations.  Fetching the list of probes is still slow, but repeated runs on pre-downloaded data are much faster now.